### PR TITLE
Optimisation

### DIFF
--- a/lua/crosshair-designer/calculate.lua
+++ b/lua/crosshair-designer/calculate.lua
@@ -1,9 +1,21 @@
-local DefaultDirection = Vector(1, 1)
+local ORIGIN = Vector(0, 0)
+local DEFAULT_DIRECTION = Vector(1, 1)
+
+local math = {}
+math.sin = _G.math.sin
+math.cos = _G.math.cos
+math.rad = _G.math.rad
+math.ceil = _G.math.ceil
+math.floor = _G.math.floor
+math.sin = _G.math.sin
+
+local Vector = Vector
 
 function CrosshairDesigner.PointsToPoly(positions)
 	local output = {}
-	for i, pos in pairs(positions) do
-		table.insert(output, Vector(pos.x, pos.y))
+
+	for k=1, #positions do
+		table.insert(output, Vector(positions[k].x, positions[k].y))
 	end
 	return output
 end
@@ -11,11 +23,11 @@ end
 function CrosshairDesigner.TranslatePoly(poly, newPos)
 	local translated = {}
 
-	for k, pos in pairs(poly) do
-		translated[k] = {x = pos.x + newPos.x, y = pos.y + newPos.y}
+	for k=1, #poly do
+		translated[k] = {x = poly[k].x + newPos.x, y = poly[k].y + newPos.y}
 	end
 
-	translated.dir = newPos.dir or DefaultDirection
+	translated.dir = newPos.dir or DEFAULT_DIRECTION
 
 	return translated
 end
@@ -23,8 +35,8 @@ end
 function CrosshairDesigner.TranslatePolys(polys, newPos)
 	local translated = {}
 
-	for k, poly in pairs(polys) do
-		translated[k] = CrosshairDesigner.TranslatePoly(poly, newPos)
+	for k=1, #polys do
+		translated[k] = CrosshairDesigner.TranslatePoly(polys[k], newPos)
 	end
 
 	return translated
@@ -33,14 +45,14 @@ end
 function CrosshairDesigner.TranslateLine(line, newPos)
 	return line[1] + newPos.x, line[2] + newPos.y,
 		line[3] + newPos.x, line[4] + newPos.y,
-		newPos.dir or DefaultDirection
+		newPos.dir or DEFAULT_DIRECTION
 end
 
 function CrosshairDesigner.TranslateLines(lines, newPos)
 	local translated = {}
 
-	for k, line in pairs(lines) do
-		translated[k] = {CrosshairDesigner.TranslateLine(line, newPos)}
+	for k=1, #lines do
+		translated[k] = {CrosshairDesigner.TranslateLine(lines[k], newPos)}
 	end
 
 	return translated
@@ -60,12 +72,12 @@ function CrosshairDesigner.RotateAroundPoint(point, radians, origin)
 end
 
 function CrosshairDesigner.RotatePoly(poly, rotation)
-	local origin = Vector(0, 0)
 	local radians = math.rad(rotation)
 	local output = {}
 
-	for i, point in pairs(poly) do
-		output[i] = CrosshairDesigner.RotateAroundPoint(point, radians, origin)
+	-- Loop through each point which makes up a poly
+	for k=1, #poly do
+		output[k] = CrosshairDesigner.RotateAroundPoint(poly[k], radians, ORIGIN)
 	end
 
 	output.dir = Vector(math.sin(radians), math.cos(radians))
@@ -74,11 +86,10 @@ function CrosshairDesigner.RotatePoly(poly, rotation)
 end
 
 function CrosshairDesigner.RotateLine(line, rotation)
-	local origin = Vector(0, 0)
 	local radians = math.rad(rotation)
 
-	local rotatedStart = CrosshairDesigner.RotateAroundPoint(Vector(line[1], line[2]), radians, origin)
-	local rotatedEnd = CrosshairDesigner.RotateAroundPoint(Vector(line[3], line[4]), radians, origin)
+	local rotatedStart = CrosshairDesigner.RotateAroundPoint(Vector(line[1], line[2]), radians, ORIGIN)
+	local rotatedEnd = CrosshairDesigner.RotateAroundPoint(Vector(line[3], line[4]), radians, ORIGIN)
 
 	return rotatedStart.x, rotatedStart.y,
 		rotatedEnd.x, rotatedEnd.y,

--- a/lua/crosshair-designer/calculate.lua
+++ b/lua/crosshair-designer/calculate.lua
@@ -9,6 +9,9 @@ math.ceil = _G.math.ceil
 math.floor = _G.math.floor
 math.sin = _G.math.sin
 
+local table = {}
+table.insert = _G.table.insert
+
 local Vector = Vector
 
 function CrosshairDesigner.PointsToPoly(positions)
@@ -24,7 +27,7 @@ function CrosshairDesigner.TranslatePoly(poly, newPos)
 	local translated = {}
 
 	for k=1, #poly do
-		translated[k] = {x = poly[k].x + newPos.x, y = poly[k].y + newPos.y}
+		translated[k] = {x = poly[k].x + newPos[1], y = poly[k].y + newPos[2]}
 	end
 
 	translated.dir = newPos.dir or DEFAULT_DIRECTION
@@ -43,8 +46,8 @@ function CrosshairDesigner.TranslatePolys(polys, newPos)
 end
 
 function CrosshairDesigner.TranslateLine(line, newPos)
-	return line[1] + newPos.x, line[2] + newPos.y,
-		line[3] + newPos.x, line[4] + newPos.y,
+	return line[1] + newPos[1], line[2] + newPos[2],
+		line[3] + newPos[1], line[4] + newPos[2],
 		newPos.dir or DEFAULT_DIRECTION
 end
 

--- a/lua/crosshair-designer/db.lua
+++ b/lua/crosshair-designer/db.lua
@@ -1,9 +1,9 @@
 CrosshairDesigner.Directory = "crosshair_designer"
 CrosshairDesigner.FutureDirectory = "crosshair_designer/remastered" -- old crosshair has good file restriction so may not need new dir
 -- but it would make it more clear for users
-
--- Outdated - the way I handled crosshair naming back in 2016 
--- so that it's forwards and backwards compatible
+local defaultCrosshair = "0 1 1 1 0 0 12 0 255 255 7 11 1 0 2 14 1 255 0 0 221 0 50 1 1 1 1 1 0 1 182 182 182 186 0 1 4 0"
+-- Outdated - the way I handled crosshair naming back in 2016
+-- so that it's forwards and backwards compatible -- To-Do: Refactor this whole file and improve saving and allow for temporary crosshairs and undos
 local saveNameConvars = {}
 table.insert(saveNameConvars, CreateClientConVar("Hc_crosssave_1", "Save 1", true, false))
 table.insert(saveNameConvars, CreateClientConVar("Hc_crosssave_2", "Save 2", true, false))
@@ -123,7 +123,7 @@ CrosshairDesigner.Load = function(crossID, dataStr)
 		end)
 	else
 		-- Hacky - remove?
-		file.Write(saveFile, "0 1 1 1 0 0 50 250 50 255 2 7 2 0 8 0 1 250 46 46 255 0 50 1 1 1 1 1") -- default config (thanks Necro)
+		file.Write(saveFile, defaultCrosshair)
 		CrosshairDesigner.Load(crossID)
 	end
 end

--- a/lua/crosshair-designer/detours.lua
+++ b/lua/crosshair-designer/detours.lua
@@ -18,7 +18,7 @@ CrosshairDesigner.AddConvarDetour = function(convar, value)
 	cvars.RemoveChangeCallback(convar, "CrosshairDesigner_DetourWarning")
 
 	cvars.AddChangeCallback(convar, function(name, oldVal, newVal)
-    	print("Thing convar is currently being detoured by CrosshairDesigner")
+    	print(name .. " convar is currently being detoured by CrosshairDesigner")
     	print("Set this value to false in the menu to remove the detour.")
     	print("If this script has been reloaded then you may need to rejoin the game.")
 	end,

--- a/lua/crosshair-designer/draw.lua
+++ b/lua/crosshair-designer/draw.lua
@@ -41,7 +41,7 @@ hook.Add("CrosshairDesigner_MenuClosed", "StopCacheStats", function()
 	menuOpenState = 0
 end)
 
-CrosshairDesigner.CacheHitRatio = function()
+CrosshairDesigner.CacheHitPercent = function()
 	return (cacheHits / (cacheHits + cacheMisses)) * 100
 end
 
@@ -716,7 +716,7 @@ concommand.Add("crosshair_designer_cache_size", function()
 end)
 
 concommand.Add("crosshairdesigner_cache_hit_ratio", function()
-	local accuracy = math.Round(CrosshairDesigner.CacheHitRatio(), 2)
+	local accuracy = math.Round(CrosshairDesigner.CacheHitPercent(), 2)
 	print(accuracy)
 	print(CrosshairDesigner.FormatBytes(CrosshairDesigner.CalcMemoryUsage()))
 end)

--- a/lua/crosshair-designer/draw.lua
+++ b/lua/crosshair-designer/draw.lua
@@ -328,15 +328,11 @@ local Crosshair = function()
 
 			-- Apply dynamic offset
 			if cachedCross["Dynamic"] then
-				--polys = CrosshairDesigner.AdjustPolysByDynamicGap(polys, dynamic, cachedCross["Rotation"])
-				--outlinePolys = CrosshairDesigner.AdjustPolysByDynamicGap(outlinePolys, dynamic, cachedCross["Rotation"])
 				polys = cacheAdjustPolysByDynamicGap(polys, false, dynamicGap, cachedCross["Rotation"])
 				outlinePolys = cacheAdjustPolysByDynamicGap(outlinePolys, true, dynamicGap, cachedCross["Rotation"])
 			end
 
 			-- Translate to middle of screen
-			--polys = CrosshairDesigner.TranslatePolys(polys, screenCentre)
-			--outlinePolys = CrosshairDesigner.TranslatePolys(outlinePolys, screenCentre)
 			polys = cacheTranslatePolys(polys, false, screenCentre, dynamicGap)
 			outlinePolys = cacheTranslatePolys(outlinePolys, true, screenCentre, dynamicGap)
 
@@ -364,15 +360,11 @@ local Crosshair = function()
 
 			-- Apply dynamic offset
 			if cachedCross["Dynamic"] then
-				--lines = CrosshairDesigner.AdjustLinesByDynamicGap(lines, dynamicGap)
-				--outlines = CrosshairDesigner.AdjustOutlinesByDynamicGap(outlines, dynamicGap)
 				lines = cacheAdjustLinesByDynamicGap(lines, dynamicGap)
 				outlines = cacheAdjustOutlinesByDynamicGap(outlines, dynamicGap)
 			end
 
 			-- Translate to middle of screen
-			--lines = CrosshairDesigner.TranslateLines(lines, screenCentre)
-			--outlines = CrosshairDesigner.TranslateLines(outlines, screenCentre)
 			lines = cacheTranslateLines(lines, false, screenCentre, dynamicGap)
 			outlines = cacheTranslateLines(outlines, true, screenCentre, dynamicGap)
 

--- a/lua/crosshair-designer/draw.lua
+++ b/lua/crosshair-designer/draw.lua
@@ -1,5 +1,58 @@
 local cachedCross = {}
+local cacheHits = 0
+local cacheMisses = 0
+local newCacheDepth = CrosshairDesigner.CacheSize()
+local cacheDepth = CrosshairDesigner.CacheSize()
 
+local surface = {}
+surface.SetDrawColor = _G.surface.SetDrawColor
+surface.DrawPoly = _G.surface.DrawPoly
+surface.DrawLine = _G.surface.DrawLine
+surface.DrawRect = _G.surface.DrawRect
+
+local math = {}
+math.Round = _G.math.Round
+math.sin = _G.math.sin
+math.cos = _G.math.cos
+math.rad = _G.math.rad
+math.max = _G.math.max
+math.min = _G.math.min
+math.floor = _G.math.floor
+math.log = _G.math.log
+math.pow = _G.math.pow
+
+local util = {}
+util.TraceLine = _G.util.TraceLine
+
+local draw = {}
+draw.NoTexture = _G.draw.NoTexture
+
+local table = {}
+table.RemoveByValue = _G.table.RemoveByValue
+table.insert = _G.table.insert
+table.Count = _G.table.Count
+
+-- Pause cache stats on menu open
+local menuOpenState = 0
+hook.Add("CrosshairDesigner_MenuOpened", "StartCacheStats", function()
+	menuOpenState = 1
+end)
+hook.Add("CrosshairDesigner_MenuClosed", "StopCacheStats", function()
+	menuOpenState = 0
+end)
+
+CrosshairDesigner.CacheHitRatio = function()
+	return (cacheHits / (cacheHits + cacheMisses)) * 100
+end
+
+-- Watch for cache size updates
+hook.Add("CrosshairDesigner_CacheSizeUpdate", "CrosshairDesigner.draw", function(newVal)
+	cacheHits = 0
+	cacheMisses = 0
+	newCacheDepth = newVal
+end)
+
+-- Centre circle generation
 local generateCircle = function(x, y, radius, seg)
 	local cir = {}
 
@@ -90,23 +143,6 @@ local screenCentre = Vector(0, 0)
 local defaultColour = Color(0,0,0,255)
 local drawCol = defaultColour
 
-local surface = {}
-surface.SetDrawColor = _G.surface.SetDrawColor
-surface.DrawPoly = _G.surface.DrawPoly
-surface.DrawLine = _G.surface.DrawLine
-surface.DrawRect = _G.surface.DrawRect
-
-local math = {}
-math.Round = _G.math.Round
-
-local util = {}
-util.TraceLine = _G.util.TraceLine
-
-local draw = {}
-draw.NoTexture = _G.draw.NoTexture
-
-CACHE_DEPTH = 5
-
 -- Cache prototype
 -- TODO: Look at removing code duplication though it seems tricky due to
 -- all the minor differences
@@ -115,6 +151,9 @@ local cache2 = {}
 cache2Ordered = {}
 local key
 local function cacheAdjustPolysByDynamicGap(polys, isOutline, dynamic, rotation)
+	if cacheDepth < 2 then
+		return CrosshairDesigner.AdjustPolysByDynamicGap(polys, dynamic, rotation)
+	end
 	-- Do not need to hash polys or rotation
 	key = tostring(isOutline) .. '-' .. tostring(dynamic)
 	if cache2[key] then
@@ -122,11 +161,12 @@ local function cacheAdjustPolysByDynamicGap(polys, isOutline, dynamic, rotation)
 		table.RemoveByValue(cache2Ordered, key)
 		table.insert(cache2Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache2Ordered > CACHE_DEPTH then
+		if #cache2Ordered > cacheDepth then
 			miss_key = cache2Ordered[#cache2Ordered]
 			table.RemoveByValue(cache2Ordered, miss_key)
 			cache2[miss_key] = nil
 		end
+		cacheHits = cacheHits + 1 - menuOpenState
 		return cache2[key]
 	else
 		-- calc new result for cache
@@ -134,11 +174,12 @@ local function cacheAdjustPolysByDynamicGap(polys, isOutline, dynamic, rotation)
 		cache2[key] = result
 		table.insert(cache2Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache2Ordered > CACHE_DEPTH then
+		if #cache2Ordered > cacheDepth then
 			miss_key = cache2Ordered[#cache2Ordered]
 			table.RemoveByValue(cache2Ordered, miss_key)
 			cache2[miss_key] = nil
 		end
+		cacheMisses = cacheMisses + 1 - menuOpenState
 		return result
 	end
 end
@@ -146,17 +187,21 @@ end
 local cache3 = {}
 cache3Ordered = {}
 local function cacheTranslatePolys(polys, isOutline, screenCentre, dynamic)
+	if cacheDepth < 2 then
+		return CrosshairDesigner.TranslatePolys(polys, screenCentre)
+	end
 	key = tostring(isOutline) .. '-' .. tostring(screenCentre) .. '-' .. tostring(dynamic)
 	if cache3[key] then
 		-- move the cache hit to the front
 		table.RemoveByValue(cache3Ordered, key)
 		table.insert(cache3Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache3Ordered > CACHE_DEPTH then
+		if #cache3Ordered > cacheDepth then
 			miss_key = cache3Ordered[#cache3Ordered]
 			table.RemoveByValue(cache3Ordered, miss_key)
 			cache3[miss_key] = nil
 		end
+		cacheHits = cacheHits + 1 - menuOpenState
 		return cache3[key]
 	else
 		-- calc new result for cache
@@ -164,11 +209,12 @@ local function cacheTranslatePolys(polys, isOutline, screenCentre, dynamic)
 		cache3[key] = result
 		table.insert(cache3Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache3Ordered > CACHE_DEPTH then
+		if #cache3Ordered > cacheDepth then
 			miss_key = cache3Ordered[#cache3Ordered]
 			table.RemoveByValue(cache3Ordered, miss_key)
 			cache3[miss_key] = nil
 		end
+		cacheMisses = cacheMisses + 1 - menuOpenState
 		return result
 	end
 end
@@ -176,17 +222,21 @@ end
 local cache4 = {}
 cache4Ordered = {}
 local function cacheAdjustLinesByDynamicGap(lines, dynamic)
+	if cacheDepth < 2 then
+		return CrosshairDesigner.AdjustLinesByDynamicGap(lines, dynamic)
+	end
 	key = tostring(dynamic)
 	if cache4[key] then
 		-- move the cache hit to the front
 		table.RemoveByValue(cache4Ordered, key)
 		table.insert(cache4Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache4Ordered > CACHE_DEPTH then
+		if #cache4Ordered > cacheDepth then
 			miss_key = cache4Ordered[#cache4Ordered]
 			table.RemoveByValue(cache4Ordered, miss_key)
 			cache4[miss_key] = nil
 		end
+		cacheHits = cacheHits + 1 - menuOpenState
 		return cache4[key]
 	else
 		-- calc new result for cache
@@ -194,11 +244,12 @@ local function cacheAdjustLinesByDynamicGap(lines, dynamic)
 		cache4[key] = CrosshairDesigner.AdjustLinesByDynamicGap(lines, dynamic)
 		table.insert(cache4Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache4Ordered > CACHE_DEPTH then
+		if #cache4Ordered > cacheDepth then
 			miss_key = cache4Ordered[#cache4Ordered]
 			table.RemoveByValue(cache4Ordered, miss_key)
 			cache4[miss_key] = nil
 		end
+		cacheMisses = cacheMisses + 1 - menuOpenState
 		return result
 	end
 end
@@ -206,17 +257,21 @@ end
 local cache5 = {}
 cache5Ordered = {}
 local function cacheAdjustOutlinesByDynamicGap(outlines, dynamic)
+	if cacheDepth < 2 then
+		return CrosshairDesigner.AdjustOutlinesByDynamicGap(outlines, dynamic)
+	end
 	key = tostring(dynamic)
 	if cache5[key] then
 		-- move the cache hit to the front
 		table.RemoveByValue(cache5Ordered, key)
 		table.insert(cache5Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache5Ordered > (CACHE_DEPTH / 2) then
+		if #cache5Ordered > (cacheDepth / 2) then
 			miss_key = cache5Ordered[#cache5Ordered]
 			table.RemoveByValue(cache5Ordered, miss_key)
 			cache5[miss_key] = nil
 		end
+		cacheHits = cacheHits + 1 - menuOpenState
 		return cache5[key]
 	else
 		-- calc new result for cache
@@ -224,11 +279,12 @@ local function cacheAdjustOutlinesByDynamicGap(outlines, dynamic)
 		cache5[key] = result
 		table.insert(cache5Ordered, 1, key)
 		-- remove a miss from the end
-		if #cache5Ordered > (CACHE_DEPTH / 2) then
+		if #cache5Ordered > (cacheDepth / 2) then
 			miss_key = cache5Ordered[#cache5Ordered]
 			table.RemoveByValue(cache5Ordered, miss_key)
 			cache5[miss_key] = nil
 		end
+		cacheMisses = cacheMisses + 1 - menuOpenState
 		return result
 	end
 end
@@ -236,17 +292,21 @@ end
 local cache6 = {}
 cache6Ordered = {}
 local function cacheTranslateLines(lines, isOutline, screenCentre, dynamic)
+	if cacheDepth < 2 then
+		return CrosshairDesigner.TranslateLines(lines, screenCentre)
+	end
 	key =  tostring(isOutline) .. '-' .. tostring(screenCentre) .. '-' .. tostring(dynamic)
 	if cache6[key] then
 		-- move the cache hit to the front
 		table.RemoveByValue(cache6Ordered, key)
 		table.insert(cache6Ordered, 0, key)
 		-- remove a miss from the end
-		if #cache6Ordered > (CACHE_DEPTH / 2) then
+		if #cache6Ordered > (cacheDepth / 2) then
 			miss_key = cache6Ordered[#cache5Ordered]
 			table.RemoveByValue(cache6Ordered, miss_key)
 			cache6[miss_key] = nil
 		end
+		cacheHits = cacheHits + 1 - menuOpenState
 		return cache6[key]
 	else
 		-- calc new result for cache
@@ -254,11 +314,12 @@ local function cacheTranslateLines(lines, isOutline, screenCentre, dynamic)
 		cache6[key] = result
 		table.insert(cache6Ordered, 0, key)
 		-- remove a miss from the end
-		if #cache6Ordered > (CACHE_DEPTH / 2) then
+		if #cache6Ordered > (cacheDepth / 2) then
 			miss_key = cache6Ordered[#cache5Ordered]
 			table.RemoveByValue(cache6Ordered, miss_key)
 			cache6[miss_key] = nil
 		end
+		cacheMisses = cacheMisses + 1 - menuOpenState
 		return result
 	end
 end
@@ -408,6 +469,76 @@ local Crosshair = function()
 		end
 	end
 
+	-- Update cache size after drawing instead of in hook.Add.
+	-- Otherwise GMod updates the value in the middle of drawing
+	-- and we get script errors with null indexes
+	if newCacheDepth ~= cacheDepth then
+		cacheDepth = newCacheDepth
+	end
+
+end
+
+CrosshairDesigner.FormatBytes = function(bytes, precision)
+	precision = precision or 2
+	-- local units = {'B', 'KiB', 'MiB', 'GiB', 'TiB'}
+
+	-- local bytes = math.max(bytes, 0)
+	-- local pow = math.floor((bytes and math.log(bytes) or 0) / math.log(1024))
+	-- pow =  math.min(pow, #units)
+
+	-- return math.Round(bytes, precision) .. ' ' .. units[pow]
+	if (bytes > math.pow(1024,3)) then
+		return math.Round(bytes / math.pow(1024,3), precision) .."GB"
+    elseif (bytes > math.pow(1024,2)) then
+    	return math.Round(bytes / math.pow(1024,2), precision) .."MB"
+    elseif (bytes > 1024) then
+    	return math.Round(bytes / 1024, precision) .."KB"
+    else
+    	return tostring(bytes).."B"
+    end
+end
+
+CrosshairDesigner.CalcMemoryUsage = function()
+	local INT_MEM = 4
+	local CHAR_MEM = 1
+
+	local ints = 0
+	local chars = 0
+
+	local intsPerLine = 5
+	local charsPerLine = 1
+	local intsPerPoly = 9
+	local charsPerPoly = 9
+
+	local info = CrosshairDesigner.CalcInfo()
+
+	-- keys (chars) representing one cache entry
+	local keyLenPerPoly = string.len("true") + (string.len("100")*2) + string.len("960.000000 540.000000 0.000000")
+	local keyLenPerLine = (string.len("true")*3) + string.len("100") + string.len("960.000000 540.000000 0.000000")
+	local keyLength = cachedCross["FillDraw"] and keyLenPerPoly or keyLenPerLine
+	-- multiplier represents the extra data stored due to everything using seaparte cache counts
+	local multiplier = cachedCross["FillDraw"] and 2 or 3
+
+	ints = (info.lines * intsPerLine * multiplier) + (info.polys * intsPerPoly * multiplier)
+	chars = (info.lines * charsPerLine * multiplier) + (info.polys * charsPerPoly * multiplier) + keyLength
+
+	usedBytes = (ints * INT_MEM) + (chars * CHAR_MEM)
+	return usedBytes
+end
+
+CrosshairDesigner.CalcInfo = function()
+	info = {}
+
+	if cachedCross["FillDraw"] then
+		info.lines = 0
+		info.polys = cachedCross["Segments"] * math.max(cachedCross["Outline"]+1, 1)
+	else
+		info.lines = (cachedCross["Segments"] * math.max(cachedCross["Thickness"], 1)) +
+						(cachedCross["Segments"] * cachedCross["Outline"] * 4)
+		info.polys = 0
+	end
+
+	return info
 end
 
 local LINE_STYLE = {
@@ -428,7 +559,8 @@ local function updateCalculated()
 	cache5Ordered = {}
 	cache6 = {}
 	cache6Ordered = {}
-
+	cacheHits = 0
+	cacheMisses = 0
 	-- Only update if all values are valid
 	local isValid, inValid = CrosshairDesigner.IsValidCrosshair({
 			["Segments"] = cachedCross["Segments"],
@@ -581,4 +713,10 @@ end)
 concommand.Add("crosshair_designer_cache_size", function()
 	size = table.Count(cache2) + table.Count(cache3) + table.Count(cache4) + table.Count(cache5) + table.Count(cache6)
 	print(size)
+end)
+
+concommand.Add("crosshairdesigner_cache_hit_ratio", function()
+	local accuracy = math.Round(CrosshairDesigner.CacheHitRatio(), 2)
+	print(accuracy)
+	print(CrosshairDesigner.FormatBytes(CrosshairDesigner.CalcMemoryUsage()))
 end)

--- a/lua/crosshair-designer/hide.lua
+++ b/lua/crosshair-designer/hide.lua
@@ -65,6 +65,7 @@ local cachedCross = {}
 
 local LocalPlayer = LocalPlayer
 local IsValid = IsValid
+local GetViewEntity = GetViewEntity
 
 -- GM:PlayerSwitchWeapon "This hook is predicted. This means that in singleplayer,
 -- it will not be called in the Client realm."
@@ -175,12 +176,10 @@ CrosshairDesigner.MakeSwepCheckTopPriority = function(name) -- untested
 end
 
 hook.Add("HUDShouldDraw", "CrosshairDesigner_ShouldHideCross", function(name)
-	-- Hide our crosshair
-	if not shouldDraw and name == "CrosshairDesiger_Crosshair" then
-		return false
-	end
-	--Hide HL2 (+TFA) crosshair
-	if name == "CHudCrosshair" and not cachedCross["ShowHL2"] then
+		-- Hide our crosshair
+	if (not shouldDraw and name == "CrosshairDesiger_Crosshair") or
+		--Hide HL2 (+TFA) crosshair
+		(name == "CHudCrosshair" and not cachedCross["ShowHL2"]) then
 		return false
 	end
 end)

--- a/lua/crosshair-designer/menu.lua
+++ b/lua/crosshair-designer/menu.lua
@@ -83,8 +83,8 @@ CrosshairDesigner.OpenMenu = function(resolutionChanged)
 		end
 
 		-- update the cache stat
-		local stat = tostring(math.Round(CrosshairDesigner.CacheHitRatio(), 2)) or "0"
-		CrosshairDesigner.Sheet.Advanced.Stat:SetText("Current cache hit ratio: " .. stat .. "%")
+		local stat = tostring(math.Round(CrosshairDesigner.CacheHitPercent(), 2)) or "0"
+		CrosshairDesigner.Sheet.Advanced.Stat:SetText("Current cache hit percent: " .. stat .. "%")
 
 		CrosshairDesigner.Sheet.Advanced.Mem.Recalculate()
 		CrosshairDesigner.Sheet.Advanced.Info.Recalculate()
@@ -336,7 +336,7 @@ CrosshairDesigner.OpenMenu = function(resolutionChanged)
     label:SetTextColor(Color(255, 255, 255, 255))
     label:SetAutoStretchVertical(true)
     label:SetWrap(true)
-    label:SetText("Cache the calculations used to generate the crosshair at each position on the screen. The bigger the cache, the more memory used but the less you need to re-calculate and the higher the cache hit ratio.")
+    label:SetText("Cache the calculations used to generate the crosshair at each position on the screen. The bigger the cache, the more memory used but the less you need to re-calculate and the higher the cache hit percent.")
     label:SetDark(1)
     label:Dock(TOP)
 	label:DockMargin(0, 5, 0, 0)
@@ -350,8 +350,8 @@ CrosshairDesigner.OpenMenu = function(resolutionChanged)
     label:Dock(TOP)
 	label:DockMargin(0, 5, 0, 0)
 	label.Recalculate = function()
-		local stat = tostring(math.Round(CrosshairDesigner.CacheHitRatio(), 2)) or "0"
-		label:SetText("Current cache hit ratio: " .. stat .. "%")
+		local stat = tostring(math.Round(CrosshairDesigner.CacheHitPercent(), 2)) or "0"
+		label:SetText("Current cache hit percent: " .. stat .. "%")
 	end
 	CrosshairDesigner.Sheet.Advanced.Stat = label
 	CrosshairDesigner.Sheet.Advanced.Stat.Recalculate()


### PR DESCRIPTION
Added in more caching and localised more functions.

In a test with a simple 8 poly crosshair. We see a ~75% decrease in total time used to draw the crosshair according to FProfiler.
0.027319600018018 vs 0.11163280001529 over a ~10 second profile.
Crosshair used: 0 1 1 1 0 0 12 0 255 255 7 11 1 0 2 14 1 255 0 0 221 0 50 1 1 1 1 1 0 1 182 182 182 186 0 1 4 0

This test was done with and without the cache turned on. I have not compared against the original code*